### PR TITLE
Introduce Reducer Trait

### DIFF
--- a/lib/sqlsync-worker/sqlsync-wasm/src/doc_task.rs
+++ b/lib/sqlsync-worker/sqlsync-wasm/src/doc_task.rs
@@ -3,7 +3,7 @@ use futures::{channel::mpsc, select, FutureExt, StreamExt};
 use rand::thread_rng;
 use sqlsync::{
     local::LocalDocument, sqlite::params_from_iter, JournalId, MemoryJournal,
-    Reducer,
+    WasmReducer,
 };
 
 use crate::{
@@ -40,7 +40,7 @@ impl DocTask {
     pub fn new(
         doc_id: JournalId,
         doc_url: Option<String>,
-        reducer: Reducer,
+        reducer: WasmReducer,
         inbox: mpsc::UnboundedReceiver<HostToWorkerMsg>,
         ports: PortRouter,
     ) -> WasmResult<Self> {

--- a/lib/sqlsync-worker/sqlsync-wasm/src/utils.rs
+++ b/lib/sqlsync-worker/sqlsync-wasm/src/utils.rs
@@ -7,7 +7,7 @@ use gloo::{
 use js_sys::{Reflect, Uint8Array};
 use log::Level;
 use sha2::{Digest, Sha256};
-use sqlsync::Reducer;
+use sqlsync::WasmReducer;
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::console;
@@ -107,7 +107,7 @@ impl_from_error!(
 
 pub async fn fetch_reducer(
     reducer_url: &str,
-) -> Result<(Reducer, Vec<u8>), WasmError> {
+) -> Result<(WasmReducer, Vec<u8>), WasmError> {
     let resp = Request::get(reducer_url).send().await?;
     if !resp.ok() {
         return Err(WasmError(anyhow!(
@@ -143,7 +143,7 @@ pub async fn fetch_reducer(
         Uint8Array::new(&digest).to_vec()
     };
 
-    let reducer = Reducer::new(reducer_wasm_bytes.as_slice())?;
+    let reducer = WasmReducer::new(reducer_wasm_bytes.as_slice())?;
 
     Ok((reducer, digest))
 }

--- a/lib/sqlsync/examples/end-to-end-local-net.rs
+++ b/lib/sqlsync/examples/end-to-end-local-net.rs
@@ -18,7 +18,7 @@ use sqlsync::replication::ReplicationProtocol;
 use sqlsync::JournalId;
 use sqlsync::Lsn;
 use sqlsync::MemoryJournalFactory;
-use sqlsync::Reducer;
+use sqlsync::WasmReducer;
 
 use serde::{Deserialize, Serialize};
 use sqlsync::{coordinator::CoordinatorDocument, MemoryJournal};
@@ -197,7 +197,7 @@ fn start_client(
     let mut doc = LocalDocument::open(
         storage_journal,
         timeline_journal,
-        Reducer::new(wasm_bytes.as_slice())?,
+        WasmReducer::new(wasm_bytes.as_slice())?,
         NoopSignal,
         NoopSignal,
         NoopSignal,

--- a/lib/sqlsync/examples/end-to-end-local.rs
+++ b/lib/sqlsync/examples/end-to-end-local.rs
@@ -11,7 +11,7 @@ use sqlsync::{
     local::{LocalDocument, NoopSignal},
     replication::ReplicationProtocol,
     sqlite::Connection,
-    JournalId, MemoryJournal, MemoryJournalFactory, Reducer,
+    JournalId, MemoryJournal, MemoryJournalFactory, WasmReducer,
 };
 
 #[derive(Debug, PartialEq)]
@@ -96,7 +96,7 @@ fn main() -> anyhow::Result<()> {
     let mut local = LocalDocument::open(
         MemoryJournal::open(doc_id)?,
         MemoryJournal::open(JournalId::new128(&mut rng))?,
-        Reducer::new(wasm_bytes.as_slice())?,
+        WasmReducer::new(wasm_bytes.as_slice())?,
         NoopSignal,
         NoopSignal,
         NoopSignal,
@@ -104,7 +104,7 @@ fn main() -> anyhow::Result<()> {
     let mut local2 = LocalDocument::open(
         MemoryJournal::open(doc_id)?,
         MemoryJournal::open(JournalId::new128(&mut rng))?,
-        Reducer::new(wasm_bytes.as_slice())?,
+        WasmReducer::new(wasm_bytes.as_slice())?,
         NoopSignal,
         NoopSignal,
         NoopSignal,
@@ -112,7 +112,7 @@ fn main() -> anyhow::Result<()> {
     let mut remote = CoordinatorDocument::open(
         MemoryJournal::open(doc_id)?,
         MemoryJournalFactory,
-        &wasm_bytes[..],
+        WasmReducer::new(wasm_bytes.as_slice())?,
     )?;
 
     let mut protocols = BTreeMap::new();

--- a/lib/sqlsync/src/coordinator.rs
+++ b/lib/sqlsync/src/coordinator.rs
@@ -5,8 +5,10 @@ use std::io;
 
 use crate::db::{open_with_vfs, ConnectionPair};
 use crate::error::Result;
-use crate::reducer::Reducer;
-use crate::replication::{ReplicationDestination, ReplicationError, ReplicationSource};
+use crate::reducer::{Reducer, WasmReducer};
+use crate::replication::{
+    ReplicationDestination, ReplicationError, ReplicationSource,
+};
 use crate::timeline::{apply_timeline_range, run_timeline_migration};
 use crate::{
     journal::{Journal, JournalFactory, JournalId},
@@ -20,8 +22,8 @@ struct ReceiveQueueEntry {
     range: LsnRange,
 }
 
-pub struct CoordinatorDocument<J: Journal> {
-    reducer: Reducer,
+pub struct CoordinatorDocument<J: Journal, R> {
+    reducer: R,
     storage: Box<Storage<J>>,
     sqlite: ConnectionPair,
     timeline_factory: J::Factory,
@@ -29,7 +31,7 @@ pub struct CoordinatorDocument<J: Journal> {
     timeline_receive_queue: VecDeque<ReceiveQueueEntry>,
 }
 
-impl<J: Journal> Debug for CoordinatorDocument<J> {
+impl<J: Journal, R> Debug for CoordinatorDocument<J, R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("CoordinatorDocument")
             .field(&self.storage)
@@ -38,11 +40,11 @@ impl<J: Journal> Debug for CoordinatorDocument<J> {
     }
 }
 
-impl<J: Journal> CoordinatorDocument<J> {
+impl<J: Journal, R: Reducer> CoordinatorDocument<J, R> {
     pub fn open(
         storage: J,
         timeline_factory: J::Factory,
-        reducer_wasm_bytes: &[u8],
+        reducer: R, // reducer_wasm_bytes: &[u8],
     ) -> Result<Self> {
         let (mut sqlite, storage) = open_with_vfs(storage)?;
 
@@ -50,7 +52,7 @@ impl<J: Journal> CoordinatorDocument<J> {
         run_timeline_migration(&mut sqlite.readwrite)?;
 
         Ok(Self {
-            reducer: Reducer::new(reducer_wasm_bytes)?,
+            reducer,
             storage,
             sqlite,
             timeline_factory,
@@ -65,7 +67,9 @@ impl<J: Journal> CoordinatorDocument<J> {
     ) -> std::result::Result<&mut J, JournalError> {
         match self.timelines.entry(id) {
             Entry::Occupied(entry) => Ok(entry.into_mut()),
-            Entry::Vacant(entry) => Ok(entry.insert(self.timeline_factory.open(id)?)),
+            Entry::Vacant(entry) => {
+                Ok(entry.insert(self.timeline_factory.open(id)?))
+            }
         }
     }
 
@@ -94,7 +98,11 @@ impl<J: Journal> CoordinatorDocument<J> {
         let entry = self.timeline_receive_queue.pop_front();
 
         if let Some(entry) = entry {
-            log::debug!("applying range {} to timeline {}", entry.range, entry.id);
+            log::debug!(
+                "applying range {} to timeline {}",
+                entry.range,
+                entry.id
+            );
 
             // get the timeline
             let timeline = self
@@ -119,7 +127,9 @@ impl<J: Journal> CoordinatorDocument<J> {
 }
 
 /// CoordinatorDocument knows how to replicate it's storage journal
-impl<J: Journal + ReplicationSource> ReplicationSource for CoordinatorDocument<J> {
+impl<J: Journal + ReplicationSource, R: Reducer> ReplicationSource
+    for CoordinatorDocument<J, R>
+{
     type Reader<'a> = <J as ReplicationSource>::Reader<'a>
     where
         Self: 'a;
@@ -132,26 +142,34 @@ impl<J: Journal + ReplicationSource> ReplicationSource for CoordinatorDocument<J
         self.storage.source_range()
     }
 
-    fn read_lsn<'a>(&'a self, lsn: crate::Lsn) -> io::Result<Option<Self::Reader<'a>>> {
+    fn read_lsn<'a>(
+        &'a self,
+        lsn: crate::Lsn,
+    ) -> io::Result<Option<Self::Reader<'a>>> {
         self.storage.read_lsn(lsn)
     }
 }
 
 /// CoordinatorDocument knows how to receive timeline journals from elsewhere
-impl<J: Journal + ReplicationDestination> ReplicationDestination for CoordinatorDocument<J> {
-    fn range(&mut self, id: JournalId) -> std::result::Result<LsnRange, ReplicationError> {
+impl<J: Journal + ReplicationDestination, R: Reducer> ReplicationDestination
+    for CoordinatorDocument<J, R>
+{
+    fn range(
+        &mut self,
+        id: JournalId,
+    ) -> std::result::Result<LsnRange, ReplicationError> {
         let timeline = self.get_or_create_timeline_mut(id)?;
         ReplicationDestination::range(timeline, id)
     }
 
-    fn write_lsn<R>(
+    fn write_lsn<Reader>(
         &mut self,
         id: JournalId,
         lsn: crate::Lsn,
-        reader: &mut R,
+        reader: &mut Reader,
     ) -> std::result::Result<(), ReplicationError>
     where
-        R: io::Read,
+        Reader: io::Read,
     {
         let timeline = self.get_or_create_timeline_mut(id)?;
         timeline.write_lsn(id, lsn, reader)?;

--- a/lib/sqlsync/src/lib.rs
+++ b/lib/sqlsync/src/lib.rs
@@ -4,7 +4,6 @@ mod journal;
 mod lsn;
 mod page;
 mod reactive_query;
-mod reducer;
 mod serialization;
 mod storage;
 mod vfs;
@@ -13,13 +12,14 @@ pub mod coordinator;
 pub mod error;
 pub mod local;
 pub mod positioned_io;
+pub mod reducer;
 pub mod replication;
 pub mod timeline;
 pub mod unixtime;
 
 pub use journal::*;
 pub use reactive_query::ReactiveQuery;
-pub use reducer::{Reducer, ReducerError};
+pub use reducer::{ReducerError, WasmReducer};
 pub use serialization::{Deserializable, Serializable};
 pub use storage::StorageChange;
 

--- a/lib/sqlsync/src/local.rs
+++ b/lib/sqlsync/src/local.rs
@@ -7,7 +7,7 @@ use crate::{
     error::Result,
     journal::{Journal, JournalId},
     lsn::LsnRange,
-    reducer::Reducer,
+    reducer::WasmReducer,
     replication::{
         ReplicationDestination, ReplicationError, ReplicationSource,
     },
@@ -26,7 +26,7 @@ impl Signal for NoopSignal {
 }
 
 pub struct LocalDocument<J, S> {
-    reducer: Reducer,
+    reducer: WasmReducer,
     timeline: J,
     storage: Box<Storage<J>>,
     sqlite: ConnectionPair,
@@ -54,7 +54,7 @@ where
     pub fn open(
         storage: J,
         timeline: J,
-        reducer: Reducer,
+        reducer: WasmReducer,
         storage_changed: S,
         timeline_changed: S,
         rebase_available: S,

--- a/lib/sqlsync/src/lsn.rs
+++ b/lib/sqlsync/src/lsn.rs
@@ -6,8 +6,6 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 /// Log Sequence Number
-///
-/// These are used to identify frames in the journal
 pub type Lsn = u64;
 
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/lib/sqlsync/src/lsn.rs
+++ b/lib/sqlsync/src/lsn.rs
@@ -5,6 +5,9 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+/// Log Sequence Number
+///
+/// These are used to identify frames in the journal
 pub type Lsn = u64;
 
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -33,9 +36,7 @@ impl LsnRange {
     }
 
     pub fn empty_following(range: &LsnRange) -> Self {
-        LsnRange::Empty {
-            nextlsn: range.next(),
-        }
+        LsnRange::Empty { nextlsn: range.next() }
     }
 
     /// returns an empty range with the nextlsn set to the first lsn of the target range
@@ -92,14 +93,8 @@ impl LsnRange {
             (LsnRange::Empty { .. }, _) => false,
             (_, LsnRange::Empty { .. }) => false,
             (
-                LsnRange::NonEmpty {
-                    first: self_first,
-                    last: self_last,
-                },
-                LsnRange::NonEmpty {
-                    first: other_first,
-                    last: other_last,
-                },
+                LsnRange::NonEmpty { first: self_first, last: self_last },
+                LsnRange::NonEmpty { first: other_first, last: other_last },
             ) => self_last >= other_first && self_first <= other_last,
         }
     }
@@ -107,10 +102,13 @@ impl LsnRange {
     pub fn immediately_preceeds(&self, other: &Self) -> bool {
         match (self, other) {
             (_, LsnRange::Empty { .. }) => false,
-            (LsnRange::Empty { nextlsn }, LsnRange::NonEmpty { first, .. }) => *nextlsn == *first,
-            (LsnRange::NonEmpty { last, .. }, LsnRange::NonEmpty { first, .. }) => {
-                last + 1 == *first
+            (LsnRange::Empty { nextlsn }, LsnRange::NonEmpty { first, .. }) => {
+                *nextlsn == *first
             }
+            (
+                LsnRange::NonEmpty { last, .. },
+                LsnRange::NonEmpty { first, .. },
+            ) => last + 1 == *first,
         }
     }
 
@@ -122,7 +120,9 @@ impl LsnRange {
         if self.contains(lsn) {
             match self {
                 LsnRange::Empty { .. } => None,
-                LsnRange::NonEmpty { first, .. } => Some(lsn.saturating_sub(*first) as usize),
+                LsnRange::NonEmpty { first, .. } => {
+                    Some(lsn.saturating_sub(*first) as usize)
+                }
             }
         } else {
             None
@@ -133,17 +133,13 @@ impl LsnRange {
         if self.intersects(other) {
             match (self, other) {
                 (
-                    LsnRange::NonEmpty {
-                        first: self_first,
-                        last: self_last,
-                    },
-                    LsnRange::NonEmpty {
-                        first: other_first,
-                        last: other_last,
-                    },
+                    LsnRange::NonEmpty { first: self_first, last: self_last },
+                    LsnRange::NonEmpty { first: other_first, last: other_last },
                 ) => {
-                    let start = std::cmp::max(*self_first, *other_first) - self_first;
-                    let end = std::cmp::min(*self_last, *other_last) - self_first + 1;
+                    let start =
+                        std::cmp::max(*self_first, *other_first) - self_first;
+                    let end =
+                        std::cmp::min(*self_last, *other_last) - self_first + 1;
                     start as usize..end as usize
                 }
                 (_, _) => 0..0,
@@ -206,8 +202,12 @@ impl LsnRange {
     pub fn extend_by(&self, len: u64) -> LsnRange {
         assert!(len > 0, "len must be > 0");
         match self {
-            LsnRange::Empty { nextlsn } => LsnRange::new(*nextlsn, nextlsn + len - 1),
-            LsnRange::NonEmpty { first, last } => LsnRange::new(*first, last + len),
+            LsnRange::Empty { nextlsn } => {
+                LsnRange::new(*nextlsn, nextlsn + len - 1)
+            }
+            LsnRange::NonEmpty { first, last } => {
+                LsnRange::new(*first, last + len)
+            }
         }
     }
 
@@ -235,10 +235,7 @@ impl LsnRange {
             }
             (
                 LsnRange::NonEmpty { first, last },
-                LsnRange::NonEmpty {
-                    first: other_first,
-                    last: other_last,
-                },
+                LsnRange::NonEmpty { first: other_first, last: other_last },
             ) => {
                 if self.intersects(other) {
                     LsnRange::new(
@@ -263,10 +260,7 @@ impl LsnRange {
 
             (
                 &LsnRange::NonEmpty { first, last },
-                &LsnRange::NonEmpty {
-                    first: ofirst,
-                    last: olast,
-                },
+                &LsnRange::NonEmpty { first: ofirst, last: olast },
             ) => {
                 // No overlap: other is entirely before or entirely after self.
                 if olast < first || ofirst > last {
@@ -276,16 +270,10 @@ impl LsnRange {
                     LsnRange::Empty { nextlsn: last + 1 }
                 } else if ofirst <= first {
                     // other overlaps start of self.
-                    LsnRange::NonEmpty {
-                        first: olast + 1,
-                        last,
-                    }
+                    LsnRange::NonEmpty { first: olast + 1, last }
                 } else if olast >= last {
                     // other overlaps end of self.
-                    LsnRange::NonEmpty {
-                        first,
-                        last: ofirst - 1,
-                    }
+                    LsnRange::NonEmpty { first, last: ofirst - 1 }
                 } else {
                     // other is entirely within self.
                     panic!("difference resulted in disjointed lsnrange")
@@ -302,7 +290,9 @@ impl LsnRange {
 impl Debug for LsnRange {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LsnRange::Empty { nextlsn } => f.debug_tuple("LsnRange::E").field(nextlsn).finish(),
+            LsnRange::Empty { nextlsn } => {
+                f.debug_tuple("LsnRange::E").field(nextlsn).finish()
+            }
             LsnRange::NonEmpty { first, last } => {
                 f.debug_tuple("LsnRange").field(first).field(last).finish()
             }


### PR DESCRIPTION
Resolves https://github.com/orbitinghail/sqlsync/issues/39

Decided to have a go at implementing the reducer trait so that custom server dead letters and such can be inserted based on mutation content and the user's specific business logic. Seems to be working fine in my server but haven't tested exhaustively. 

Then users can use it like so

```rust 
struct CustomReducer {
    wasm_reducer: sqlsync::reducer::WasmReducer,
}

impl sqlsync::reducer::Reducer for CustomReducer {
    fn apply(
        &mut self,
        tx: &mut sqlsync::sqlite::Transaction,
        mutation: &[u8],
    ) -> sqlsync::reducer::Result<()> {
        // custom logic goes here
        /*
        match self.customInner.validate(mutation) => { 
            Err(e) => { 
                tx.execute("INSERT INTO errors (error) VALUES (?)", params![e.to_string()])?;
            }
        }
         */

		// can use SQLSync WasmReducer or just use the tx handle yourself?
        self.wasm_reducer.apply(tx, mutation)
    }
}
```

Most of the lines are changed because of auto formatting.