### PR TITLE
Server-initiated mutations

### DIFF
--- a/lib/sqlsync-worker/sqlsync-wasm/src/utils.rs
+++ b/lib/sqlsync-worker/sqlsync-wasm/src/utils.rs
@@ -95,7 +95,6 @@ impl_from_error!(
     io::Error,
     sqlsync::error::Error,
     sqlsync::sqlite::Error,
-    sqlsync::JournalError,
     sqlsync::replication::ReplicationError,
     sqlsync::JournalIdParseError,
     sqlsync::ReducerError,

--- a/lib/sqlsync/src/coordinator.rs
+++ b/lib/sqlsync/src/coordinator.rs
@@ -1,19 +1,24 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
+use std::convert::From;
 use std::fmt::Debug;
 use std::io;
 
-use crate::db::{open_with_vfs, ConnectionPair};
+use rusqlite::Transaction;
+
+use crate::db::{open_with_vfs, run_in_tx, ConnectionPair};
 use crate::error::Result;
 use crate::reducer::Reducer;
-use crate::replication::{ReplicationDestination, ReplicationError, ReplicationSource};
+use crate::replication::{
+    ReplicationDestination, ReplicationError, ReplicationSource,
+};
 use crate::timeline::{apply_timeline_range, run_timeline_migration};
+use crate::Lsn;
 use crate::{
     journal::{Journal, JournalFactory, JournalId},
     lsn::LsnRange,
     storage::Storage,
 };
-use crate::{JournalError, Lsn};
 
 struct ReceiveQueueEntry {
     id: JournalId,
@@ -44,10 +49,11 @@ impl<J: Journal> CoordinatorDocument<J> {
         timeline_factory: J::Factory,
         reducer_wasm_bytes: &[u8],
     ) -> Result<Self> {
-        let (mut sqlite, storage) = open_with_vfs(storage)?;
+        let (mut sqlite, mut storage) = open_with_vfs(storage)?;
 
         // TODO: this feels awkward here
         run_timeline_migration(&mut sqlite.readwrite)?;
+        storage.commit()?;
 
         Ok(Self {
             reducer: Reducer::new(reducer_wasm_bytes)?,
@@ -62,10 +68,12 @@ impl<J: Journal> CoordinatorDocument<J> {
     fn get_or_create_timeline_mut(
         &mut self,
         id: JournalId,
-    ) -> std::result::Result<&mut J, JournalError> {
+    ) -> io::Result<&mut J> {
         match self.timelines.entry(id) {
             Entry::Occupied(entry) => Ok(entry.into_mut()),
-            Entry::Vacant(entry) => Ok(entry.insert(self.timeline_factory.open(id)?)),
+            Entry::Vacant(entry) => {
+                Ok(entry.insert(self.timeline_factory.open(id)?))
+            }
         }
     }
 
@@ -89,12 +97,26 @@ impl<J: Journal> CoordinatorDocument<J> {
         }
     }
 
+    pub fn mutate_direct<F, E>(&mut self, f: F) -> Result<(), E>
+    where
+        F: FnOnce(&mut Transaction) -> Result<(), E>,
+        E: From<rusqlite::Error> + From<io::Error>,
+    {
+        run_in_tx(&mut self.sqlite.readwrite, f)?;
+        self.storage.commit()?;
+        Ok(())
+    }
+
     pub fn step(&mut self) -> Result<()> {
         // check to see if we have anything in the receive queue
         let entry = self.timeline_receive_queue.pop_front();
 
         if let Some(entry) = entry {
-            log::debug!("applying range {} to timeline {}", entry.range, entry.id);
+            log::debug!(
+                "applying range {} to timeline {}",
+                entry.range,
+                entry.id
+            );
 
             // get the timeline
             let timeline = self
@@ -119,7 +141,9 @@ impl<J: Journal> CoordinatorDocument<J> {
 }
 
 /// CoordinatorDocument knows how to replicate it's storage journal
-impl<J: Journal + ReplicationSource> ReplicationSource for CoordinatorDocument<J> {
+impl<J: Journal + ReplicationSource> ReplicationSource
+    for CoordinatorDocument<J>
+{
     type Reader<'a> = <J as ReplicationSource>::Reader<'a>
     where
         Self: 'a;
@@ -132,14 +156,22 @@ impl<J: Journal + ReplicationSource> ReplicationSource for CoordinatorDocument<J
         self.storage.source_range()
     }
 
-    fn read_lsn<'a>(&'a self, lsn: crate::Lsn) -> io::Result<Option<Self::Reader<'a>>> {
+    fn read_lsn<'a>(
+        &'a self,
+        lsn: crate::Lsn,
+    ) -> io::Result<Option<Self::Reader<'a>>> {
         self.storage.read_lsn(lsn)
     }
 }
 
 /// CoordinatorDocument knows how to receive timeline journals from elsewhere
-impl<J: Journal + ReplicationDestination> ReplicationDestination for CoordinatorDocument<J> {
-    fn range(&mut self, id: JournalId) -> std::result::Result<LsnRange, ReplicationError> {
+impl<J: Journal + ReplicationDestination> ReplicationDestination
+    for CoordinatorDocument<J>
+{
+    fn range(
+        &mut self,
+        id: JournalId,
+    ) -> std::result::Result<LsnRange, ReplicationError> {
         let timeline = self.get_or_create_timeline_mut(id)?;
         ReplicationDestination::range(timeline, id)
     }

--- a/lib/sqlsync/src/error.rs
+++ b/lib/sqlsync/src/error.rs
@@ -1,17 +1,16 @@
+use std::io;
+
 use thiserror::Error;
 
 use crate::{
-    reducer::ReducerError, replication::ReplicationError, timeline::TimelineError, JournalError,
-    JournalIdParseError,
+    reducer::ReducerError, replication::ReplicationError,
+    timeline::TimelineError, JournalIdParseError,
 };
 
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]
     ReplicationError(#[from] ReplicationError),
-
-    #[error(transparent)]
-    JournalError(#[from] JournalError),
 
     #[error(transparent)]
     JournalIdParseError(#[from] JournalIdParseError),
@@ -24,6 +23,9 @@ pub enum Error {
 
     #[error(transparent)]
     SqliteError(#[from] rusqlite::Error),
+
+    #[error("io error: {0}")]
+    IoError(#[from] io::Error),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/lib/sqlsync/src/journal/cursor.rs
+++ b/lib/sqlsync/src/journal/cursor.rs
@@ -28,11 +28,7 @@ pub struct Cursor<'a, S: Scannable, I> {
 
 impl<'a, S: Scannable, I: DoubleEndedIterator<Item = Lsn>> Cursor<'a, S, I> {
     pub fn new(inner: &'a S, lsn_iter: I) -> Self {
-        Self {
-            inner,
-            lsn_iter,
-            state: None,
-        }
+        Self { inner, lsn_iter, state: None }
     }
 
     /// advance the cursor
@@ -60,11 +56,7 @@ impl<'a, S: Scannable, I: DoubleEndedIterator<Item = Lsn>> Cursor<'a, S, I> {
 
     /// reverse this cursor
     pub fn into_rev(self) -> Cursor<'a, S, Rev<I>> {
-        Cursor {
-            inner: self.inner,
-            lsn_iter: self.lsn_iter.rev(),
-            state: None,
-        }
+        Cursor { inner: self.inner, lsn_iter: self.lsn_iter.rev(), state: None }
     }
 }
 

--- a/lib/sqlsync/src/journal/journal.rs
+++ b/lib/sqlsync/src/journal/journal.rs
@@ -1,8 +1,5 @@
 use std::fmt::Debug;
 use std::io;
-use std::result::Result;
-
-use thiserror::Error;
 
 use crate::Serializable;
 use crate::{
@@ -11,17 +8,6 @@ use crate::{
 };
 
 use super::Scannable;
-
-#[derive(Error, Debug)]
-pub enum JournalError {
-    #[error("io error: {0}")]
-    IoError(#[from] io::Error),
-
-    #[error("failed to serialize object")]
-    SerializationError(#[source] io::Error),
-}
-
-pub type JournalResult<T> = Result<T, JournalError>;
 
 pub trait Journal: Scannable + Debug + Sized {
     type Factory: JournalFactory<Self>;
@@ -33,12 +19,12 @@ pub trait Journal: Scannable + Debug + Sized {
     fn range(&self) -> LsnRange;
 
     /// append a new journal entry, and then write to it
-    fn append(&mut self, obj: impl Serializable) -> JournalResult<()>;
+    fn append(&mut self, obj: impl Serializable) -> io::Result<()>;
 
     /// drop the journal's prefix
-    fn drop_prefix(&mut self, up_to: Lsn) -> JournalResult<()>;
+    fn drop_prefix(&mut self, up_to: Lsn) -> io::Result<()>;
 }
 
 pub trait JournalFactory<J> {
-    fn open(&self, id: JournalId) -> JournalResult<J>;
+    fn open(&self, id: JournalId) -> io::Result<J>;
 }


### PR DESCRIPTION
Fixes #42

This PR introduces a new method on the `CoordinatorDocument` type called `mutate_direct` which allows direct access to the underlying sqlite database. Any changes made to the underlying sqlite database will be propagated to all clients.